### PR TITLE
Tightening up the error checking in the xfn scraping example

### DIFF
--- a/python_code/microformats__xfn_scrape.py
+++ b/python_code/microformats__xfn_scrape.py
@@ -31,13 +31,13 @@ XFN_TAGS = set([
 
 try:
     page = urllib2.urlopen(URL)
-except urllib2.URLError:
-    print 'Failed to fetch ' + item
-
-try:
     soup = BeautifulSoup(page)
+except urllib2.URLError:
+    print 'Failed to fetch ' + URL
+    sys.exit()
 except HTMLParser.HTMLParseError:
-    print 'Failed to parse ' + item
+    print 'Failed to parse ' + URL
+    sys.exit()
 
 anchorTags = soup.findAll('a')
 


### PR DESCRIPTION
I noticed (after fat-fingering a URL) that the error checking code in the xfn scraping example was referring to a non-existent local variable 'item'. Also, the program continued executing after I encountered the 'Failed to fetch' error, so I got exception output complaining that the 'page' variable was not defined.
