### PR TITLE
Set Content-Type header for POST to couchdb _all_docs

### DIFF
--- a/python_code/mailboxes__participants_in_conversations.py
+++ b/python_code/mailboxes__participants_in_conversations.py
@@ -84,7 +84,8 @@ message_ids_for_threads_of_interest = list(set([message_id for message_ids in
 try:
     conn = httplib.HTTPConnection('localhost', 5984)
     post_params = json.dumps({'keys': message_ids_for_threads_of_interest})
-    conn.request('POST', '/%s/_all_docs?include_docs=true' % (DB, ), post_params)
+    headers = { 'Content-Type': 'application/json;charset=utf-8' }
+    conn.request('POST', '/%s/_all_docs?include_docs=true' % (DB, ), post_params, headers)
     response = conn.getresponse()
     if response.status != 200:  #  OK
         print 'Unable to get docs: %s %s' % (response.status, response.reason)

--- a/python_code/mailboxes__participants_in_conversations_adapted_for_simile.py
+++ b/python_code/mailboxes__participants_in_conversations_adapted_for_simile.py
@@ -93,7 +93,8 @@ message_ids_for_threads_of_interest = list(set([message_id for message_ids in
 try:
     conn = httplib.HTTPConnection('localhost', 5984)
     post_params = json.dumps({'keys': message_ids_for_threads_of_interest})
-    conn.request('POST', '/%s/_all_docs?include_docs=true' % (DB, ), post_params)
+    headers = { 'Content-Type': 'application/json;charset=utf-8' }
+    conn.request('POST', '/%s/_all_docs?include_docs=true' % (DB, ), post_params, headers)
     response = conn.getresponse()
     if response.status != 200:  #  OK
         print 'Unable to get docs: %s %s' % (response.status, response.reason)


### PR DESCRIPTION
In Example 3-18 we use a POST to query CouchDB, passing the required keys as JSON in the body. 

When I tried running this, CouchDB 1.1.1 replied with `415 Unsupported Media Type`. 
Setting the Content-Type header in the request fixed it.
