### PR TITLE
Update python_code/mailboxes__convert_enron_inbox_to_mbox.py

### DIFF
--- a/python_code/mailboxes__convert_enron_inbox_to_mbox.py
+++ b/python_code/mailboxes__convert_enron_inbox_to_mbox.py
@@ -5,7 +5,7 @@ import email
 from time import asctime
 import os
 import sys
-from dateutil.parser import parse  # easy_install dateutil
+from dateutil.parser import parse  # easy_install python_dateutil
 
 directory = sys.argv[1]
 


### PR DESCRIPTION
the pypi name of dateutil module is python-dateutil

http://pypi.python.org/pypi/python-dateutil

I use pip so didn't tested the easy_install command
